### PR TITLE
Replace use of Map<String, String> with ProxyMap of headers.

### DIFF
--- a/src/main/java/io/roastedroot/proxywasm/ArrayProxyMap.java
+++ b/src/main/java/io/roastedroot/proxywasm/ArrayProxyMap.java
@@ -1,0 +1,86 @@
+package io.roastedroot.proxywasm;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+
+public class ArrayProxyMap implements ProxyMap {
+
+    final ArrayList<Map.Entry<String, String>> entries;
+
+    public ArrayProxyMap() {
+        this.entries = new ArrayList<>();
+    }
+
+    public ArrayProxyMap(int mapSize) {
+        this.entries = new ArrayList<>(mapSize);
+    }
+
+    public ArrayProxyMap(ProxyMap other) {
+        this(other.size());
+        for (Map.Entry<String, String> entry : other.entries()) {
+            add(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public ArrayProxyMap(Map<String, String> other) {
+        this(other.size());
+        for (Map.Entry<String, String> entry : other.entrySet()) {
+            add(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Override
+    public int size() {
+        return entries.size();
+    }
+
+    @Override
+    public void add(String key, String value) {
+        entries.add(Map.entry(key, value));
+    }
+
+    @Override
+    public void put(String key, String value) {
+        this.remove(key);
+        entries.add(Map.entry(key, value));
+    }
+
+    @Override
+    public Iterable<? extends Map.Entry<String, String>> entries() {
+        return entries;
+    }
+
+    @Override
+    public String get(String key) {
+        return entries.stream()
+                .filter(x -> x.getKey().equals(key))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    public void remove(String key) {
+        entries.removeIf(x -> x.getKey().equals(key));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ArrayProxyMap that = (ArrayProxyMap) o;
+        return Objects.equals(entries, that.entries);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(entries);
+    }
+
+    @Override
+    public String toString() {
+        return entries.toString();
+    }
+}

--- a/src/main/java/io/roastedroot/proxywasm/ChainedHandler.java
+++ b/src/main/java/io/roastedroot/proxywasm/ChainedHandler.java
@@ -1,8 +1,5 @@
 package io.roastedroot.proxywasm;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * A Handler implementation that chains to another handler if it can't handle the request.
  */
@@ -16,92 +13,92 @@ public abstract class ChainedHandler implements Handler {
     }
 
     @Override
-    public Map<String, String> getHttpRequestHeaders() {
+    public ProxyMap getHttpRequestHeaders() {
         return next().getHttpRequestHeaders();
     }
 
     @Override
-    public Map<String, String> getHttpRequestTrailers() {
+    public ProxyMap getHttpRequestTrailers() {
         return next().getHttpRequestTrailers();
     }
 
     @Override
-    public Map<String, String> getHttpResponseHeaders() {
+    public ProxyMap getHttpResponseHeaders() {
         return next().getHttpResponseHeaders();
     }
 
     @Override
-    public Map<String, String> getHttpResponseTrailers() {
+    public ProxyMap getHttpResponseTrailers() {
         return next().getHttpResponseTrailers();
     }
 
     @Override
-    public Map<String, String> getHttpCallResponseHeaders() {
+    public ProxyMap getHttpCallResponseHeaders() {
         return next().getHttpCallResponseHeaders();
     }
 
     @Override
-    public Map<String, String> getHttpCallResponseTrailers() {
+    public ProxyMap getHttpCallResponseTrailers() {
         return next().getHttpCallResponseTrailers();
     }
 
     @Override
-    public Map<String, String> getGrpcReceiveInitialMetaData() {
+    public ProxyMap getGrpcReceiveInitialMetaData() {
         return next().getGrpcReceiveInitialMetaData();
     }
 
     @Override
-    public Map<String, String> getGrpcReceiveTrailerMetaData() {
+    public ProxyMap getGrpcReceiveTrailerMetaData() {
         return next().getGrpcReceiveTrailerMetaData();
     }
 
     @Override
-    public Map<String, String> getCustomHeaders(int mapType) {
+    public ProxyMap getCustomHeaders(int mapType) {
         return next().getCustomHeaders(mapType);
     }
 
     @Override
-    public WasmResult setCustomHeaders(int mapType, Map<String, String> map) {
+    public WasmResult setCustomHeaders(int mapType, ProxyMap map) {
         return next().setCustomHeaders(mapType, map);
     }
 
     @Override
-    public WasmResult setHttpRequestHeaders(Map<String, String> headers) {
+    public WasmResult setHttpRequestHeaders(ProxyMap headers) {
         return next().setHttpRequestHeaders(headers);
     }
 
     @Override
-    public WasmResult setHttpRequestTrailers(Map<String, String> trailers) {
+    public WasmResult setHttpRequestTrailers(ProxyMap trailers) {
         return next().setHttpRequestTrailers(trailers);
     }
 
     @Override
-    public WasmResult setHttpResponseHeaders(Map<String, String> headers) {
+    public WasmResult setHttpResponseHeaders(ProxyMap headers) {
         return next().setHttpResponseHeaders(headers);
     }
 
     @Override
-    public WasmResult setHttpResponseTrailers(Map<String, String> trailers) {
+    public WasmResult setHttpResponseTrailers(ProxyMap trailers) {
         return next().setHttpResponseTrailers(trailers);
     }
 
     @Override
-    public WasmResult setHttpCallResponseHeaders(Map<String, String> headers) {
+    public WasmResult setHttpCallResponseHeaders(ProxyMap headers) {
         return next().setHttpCallResponseHeaders(headers);
     }
 
     @Override
-    public WasmResult setHttpCallResponseTrailers(Map<String, String> trailers) {
+    public WasmResult setHttpCallResponseTrailers(ProxyMap trailers) {
         return next().setHttpCallResponseTrailers(trailers);
     }
 
     @Override
-    public WasmResult setGrpcReceiveInitialMetaData(Map<String, String> metadata) {
+    public WasmResult setGrpcReceiveInitialMetaData(ProxyMap metadata) {
         return next().setGrpcReceiveInitialMetaData(metadata);
     }
 
     @Override
-    public WasmResult setGrpcReceiveTrailerMetaData(Map<String, String> metadata) {
+    public WasmResult setGrpcReceiveTrailerMetaData(ProxyMap metadata) {
         return next().setGrpcReceiveTrailerMetaData(metadata);
     }
 
@@ -185,7 +182,7 @@ public abstract class ChainedHandler implements Handler {
             int responseCode,
             byte[] responseCodeDetails,
             byte[] responseBody,
-            Map<String, String> additionalHeaders,
+            ProxyMap additionalHeaders,
             int grpcStatus) {
         return next().sendHttpResponse(
                         responseCode,
@@ -246,12 +243,7 @@ public abstract class ChainedHandler implements Handler {
     }
 
     @Override
-    public int httpCall(
-            String uri,
-            HashMap<String, String> headers,
-            byte[] body,
-            HashMap<String, String> trailers,
-            int timeout)
+    public int httpCall(String uri, ProxyMap headers, byte[] body, ProxyMap trailers, int timeout)
             throws WasmException {
         return next().httpCall(uri, headers, body, trailers, timeout);
     }
@@ -259,9 +251,9 @@ public abstract class ChainedHandler implements Handler {
     @Override
     public int dispatchHttpCall(
             String upstreamName,
-            HashMap<String, String> headers,
+            ProxyMap headers,
             byte[] body,
-            HashMap<String, String> trailers,
+            ProxyMap trailers,
             int timeoutMilliseconds)
             throws WasmException {
         return next().dispatchHttpCall(upstreamName, headers, body, trailers, timeoutMilliseconds);

--- a/src/main/java/io/roastedroot/proxywasm/Handler.java
+++ b/src/main/java/io/roastedroot/proxywasm/Handler.java
@@ -1,8 +1,5 @@
 package io.roastedroot.proxywasm;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public interface Handler {
 
     default void log(LogLevel level, String message) throws WasmException {}
@@ -12,39 +9,39 @@ public interface Handler {
     }
 
     // TODO: use a better type than Map so that we can support repeated headers
-    default Map<String, String> getHttpRequestHeaders() {
+    default ProxyMap getHttpRequestHeaders() {
         return null;
     }
 
-    default Map<String, String> getHttpRequestTrailers() {
+    default ProxyMap getHttpRequestTrailers() {
         return null;
     }
 
-    default Map<String, String> getHttpResponseHeaders() {
+    default ProxyMap getHttpResponseHeaders() {
         return null;
     }
 
-    default Map<String, String> getHttpResponseTrailers() {
+    default ProxyMap getHttpResponseTrailers() {
         return null;
     }
 
-    default Map<String, String> getHttpCallResponseHeaders() {
+    default ProxyMap getHttpCallResponseHeaders() {
         return null;
     }
 
-    default Map<String, String> getHttpCallResponseTrailers() {
+    default ProxyMap getHttpCallResponseTrailers() {
         return null;
     }
 
-    default Map<String, String> getGrpcReceiveInitialMetaData() {
+    default ProxyMap getGrpcReceiveInitialMetaData() {
         return null;
     }
 
-    default Map<String, String> getGrpcReceiveTrailerMetaData() {
+    default ProxyMap getGrpcReceiveTrailerMetaData() {
         return null;
     }
 
-    default Map<String, String> getCustomHeaders(int mapType) {
+    default ProxyMap getCustomHeaders(int mapType) {
         return null;
     }
 
@@ -198,7 +195,7 @@ public interface Handler {
             int responseCode,
             byte[] responseCodeDetails,
             byte[] responseBody,
-            Map<String, String> additionalHeaders,
+            ProxyMap additionalHeaders,
             int grpcStatus) {
         return WasmResult.UNIMPLEMENTED;
     }
@@ -291,7 +288,7 @@ public interface Handler {
      * @param map     The header map to set
      * @return WasmResult indicating success or failure
      */
-    default WasmResult setCustomHeaders(int mapType, Map<String, String> map) {
+    default WasmResult setCustomHeaders(int mapType, ProxyMap map) {
         return WasmResult.UNIMPLEMENTED;
     }
 
@@ -301,7 +298,7 @@ public interface Handler {
      * @param headers The headers to set
      * @return WasmResult indicating success or failure
      */
-    default WasmResult setHttpRequestHeaders(Map<String, String> headers) {
+    default WasmResult setHttpRequestHeaders(ProxyMap headers) {
         return WasmResult.UNIMPLEMENTED;
     }
 
@@ -311,7 +308,7 @@ public interface Handler {
      * @param trailers The trailers to set
      * @return WasmResult indicating success or failure
      */
-    default WasmResult setHttpRequestTrailers(Map<String, String> trailers) {
+    default WasmResult setHttpRequestTrailers(ProxyMap trailers) {
         return WasmResult.UNIMPLEMENTED;
     }
 
@@ -321,7 +318,7 @@ public interface Handler {
      * @param headers The headers to set
      * @return WasmResult indicating success or failure
      */
-    default WasmResult setHttpResponseHeaders(Map<String, String> headers) {
+    default WasmResult setHttpResponseHeaders(ProxyMap headers) {
         return WasmResult.UNIMPLEMENTED;
     }
 
@@ -331,7 +328,7 @@ public interface Handler {
      * @param trailers The trailers to set
      * @return WasmResult indicating success or failure
      */
-    default WasmResult setHttpResponseTrailers(Map<String, String> trailers) {
+    default WasmResult setHttpResponseTrailers(ProxyMap trailers) {
         return WasmResult.UNIMPLEMENTED;
     }
 
@@ -341,7 +338,7 @@ public interface Handler {
      * @param headers The headers to set
      * @return WasmResult indicating success or failure
      */
-    default WasmResult setHttpCallResponseHeaders(Map<String, String> headers) {
+    default WasmResult setHttpCallResponseHeaders(ProxyMap headers) {
         return WasmResult.UNIMPLEMENTED;
     }
 
@@ -351,7 +348,7 @@ public interface Handler {
      * @param trailers The trailers to set
      * @return WasmResult indicating success or failure
      */
-    default WasmResult setHttpCallResponseTrailers(Map<String, String> trailers) {
+    default WasmResult setHttpCallResponseTrailers(ProxyMap trailers) {
         return WasmResult.UNIMPLEMENTED;
     }
 
@@ -361,7 +358,7 @@ public interface Handler {
      * @param metadata The metadata to set
      * @return WasmResult indicating success or failure
      */
-    default WasmResult setGrpcReceiveInitialMetaData(Map<String, String> metadata) {
+    default WasmResult setGrpcReceiveInitialMetaData(ProxyMap metadata) {
         return WasmResult.UNIMPLEMENTED;
     }
 
@@ -371,7 +368,7 @@ public interface Handler {
      * @param metadata The metadata to set
      * @return WasmResult indicating success or failure
      */
-    default WasmResult setGrpcReceiveTrailerMetaData(Map<String, String> metadata) {
+    default WasmResult setGrpcReceiveTrailerMetaData(ProxyMap metadata) {
         return WasmResult.UNIMPLEMENTED;
     }
 
@@ -384,20 +381,16 @@ public interface Handler {
     }
 
     default int httpCall(
-            String uri,
-            HashMap<String, String> headers,
-            byte[] body,
-            HashMap<String, String> trailers,
-            int timeoutMilliseconds)
+            String uri, ProxyMap headers, byte[] body, ProxyMap trailers, int timeoutMilliseconds)
             throws WasmException {
         throw new WasmException(WasmResult.UNIMPLEMENTED);
     }
 
     default int dispatchHttpCall(
             String upstreamName,
-            HashMap<String, String> headers,
+            ProxyMap headers,
             byte[] body,
-            HashMap<String, String> trailers,
+            ProxyMap trailers,
             int timeoutMilliseconds)
             throws WasmException {
         throw new WasmException(WasmResult.UNIMPLEMENTED);

--- a/src/main/java/io/roastedroot/proxywasm/Helpers.java
+++ b/src/main/java/io/roastedroot/proxywasm/Helpers.java
@@ -37,6 +37,13 @@ public final class Helpers {
         return value.length;
     }
 
+    public static int len(ProxyMap value) {
+        if (value == null) {
+            return 0;
+        }
+        return value.size();
+    }
+
     public static <T> int len(String value) {
         if (value == null) {
             return 0;

--- a/src/main/java/io/roastedroot/proxywasm/ProxyMap.java
+++ b/src/main/java/io/roastedroot/proxywasm/ProxyMap.java
@@ -1,0 +1,36 @@
+package io.roastedroot.proxywasm;
+
+import java.util.Map;
+
+public interface ProxyMap {
+
+    static ProxyMap of(String... values) {
+        if (values.length % 2 != 0) {
+            throw new IllegalArgumentException("values must be even");
+        }
+        ArrayProxyMap map = new ArrayProxyMap(values.length / 2);
+        for (int i = 0; i < values.length; i += 2) {
+            map.add(values[i], values[i + 1]);
+        }
+        return map;
+    }
+
+    static ProxyMap copyOf(Map<String, String> headers) {
+        if (headers == null) {
+            return null;
+        }
+        return new ArrayProxyMap(headers);
+    }
+
+    int size();
+
+    void add(String key, String value);
+
+    void put(String key, String value);
+
+    Iterable<? extends Map.Entry<String, String>> entries();
+
+    String get(String key);
+
+    void remove(String key);
+}

--- a/src/main/java/io/roastedroot/proxywasm/ProxyWasm.java
+++ b/src/main/java/io/roastedroot/proxywasm/ProxyWasm.java
@@ -34,8 +34,8 @@ public final class ProxyWasm implements Closeable {
     private Context activeContext;
 
     private HashMap<Integer, Context> contexts = new HashMap<>();
-    private Map<String, String> httpCallResponseHeaders;
-    private Map<String, String> httpCallResponseTrailers;
+    private ProxyMap httpCallResponseHeaders;
+    private ProxyMap httpCallResponseTrailers;
     private byte[] httpCallResponseBody;
     private HashMap<String, ForeignFunction> foreignFunctions = new HashMap<>();
 
@@ -120,12 +120,12 @@ public final class ProxyWasm implements Closeable {
             }
 
             @Override
-            public Map<String, String> getHttpCallResponseHeaders() {
+            public ProxyMap getHttpCallResponseHeaders() {
                 return httpCallResponseHeaders;
             }
 
             @Override
-            public Map<String, String> getHttpCallResponseTrailers() {
+            public ProxyMap getHttpCallResponseTrailers() {
                 return httpCallResponseTrailers;
             }
 
@@ -220,6 +220,12 @@ public final class ProxyWasm implements Closeable {
 
     public void sendHttpCallResponse(
             int calloutID, Map<String, String> headers, Map<String, String> trailers, byte[] body) {
+        this.sendHttpCallResponse(
+                calloutID, ProxyMap.copyOf(headers), ProxyMap.copyOf(trailers), body);
+    }
+
+    public void sendHttpCallResponse(
+            int calloutID, ProxyMap headers, ProxyMap trailers, byte[] body) {
 
         this.httpCallResponseHeaders = headers;
         this.httpCallResponseTrailers = trailers;

--- a/src/test/java/io/roastedroot/proxywasm/examples/HttpAuthRandomTest.java
+++ b/src/test/java/io/roastedroot/proxywasm/examples/HttpAuthRandomTest.java
@@ -8,10 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.dylibso.chicory.wasm.Parser;
 import io.roastedroot.proxywasm.Action;
+import io.roastedroot.proxywasm.ProxyMap;
 import io.roastedroot.proxywasm.ProxyWasm;
 import io.roastedroot.proxywasm.StartException;
 import java.nio.file.Path;
-import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,7 +45,7 @@ public class HttpAuthRandomTest {
         try (var context = host.createHttpContext(handler)) {
 
             // Call OnRequestHeaders.
-            handler.setHttpRequestHeaders(Map.of("key", "value"));
+            handler.setHttpRequestHeaders(ProxyMap.of("key", "value"));
             var action = context.callOnRequestHeaders(false);
             Assertions.assertEquals(Action.PAUSE, action);
 
@@ -64,7 +64,7 @@ public class HttpAuthRandomTest {
     @Test
     public void onHttpCallResponse() throws StartException {
         var headers =
-                Map.of(
+                ProxyMap.of(
                         "HTTP/1.1", "200 OK",
                         "Date:", "Thu, 17 Sep 2020 02:47:07 GMT",
                         "Content-Type", "application/json",
@@ -78,7 +78,7 @@ public class HttpAuthRandomTest {
         try (var context = host.createHttpContext(handler)) {
 
             // Call OnRequestHeaders.
-            handler.setHttpRequestHeaders(Map.of());
+            handler.setHttpRequestHeaders(ProxyMap.of());
             var action = context.callOnRequestHeaders(false);
             assertEquals(Action.PAUSE, action);
 
@@ -101,7 +101,7 @@ public class HttpAuthRandomTest {
         try (var context = host.createHttpContext(handler)) {
 
             // Call OnRequestHeaders.
-            handler.setHttpRequestHeaders(Map.of());
+            handler.setHttpRequestHeaders(ProxyMap.of());
             var action = context.callOnRequestHeaders(false);
             assertEquals(Action.PAUSE, action);
 
@@ -116,7 +116,7 @@ public class HttpAuthRandomTest {
             assertNotNull(localResponse);
             assertEquals(403, localResponse.statusCode);
             assertEquals("access forbidden", string(localResponse.body));
-            assertEquals(Map.of("powered-by", "proxy-wasm-go-sdk!!"), localResponse.headers);
+            assertEquals(ProxyMap.of("powered-by", "proxy-wasm-go-sdk!!"), localResponse.headers);
 
             // CHeck Envoy logs.
             handler.assertLogsContain("access forbidden");

--- a/src/test/java/io/roastedroot/proxywasm/examples/HttpBodyTest.java
+++ b/src/test/java/io/roastedroot/proxywasm/examples/HttpBodyTest.java
@@ -8,11 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.dylibso.chicory.wasm.Parser;
 import io.roastedroot.proxywasm.Action;
 import io.roastedroot.proxywasm.HttpContext;
+import io.roastedroot.proxywasm.ProxyMap;
 import io.roastedroot.proxywasm.ProxyWasm;
 import io.roastedroot.proxywasm.StartException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,7 +47,7 @@ public class HttpBodyTest {
 
         // Call OnRequestHeaders.
         handler.setHttpRequestHeaders(
-                Map.of(
+                ProxyMap.of(
                         "content-length", "10",
                         "buffer-operation", "replace"));
         var action = httpContext.callOnRequestHeaders(false);
@@ -56,7 +56,7 @@ public class HttpBodyTest {
         Assertions.assertEquals(Action.CONTINUE, action);
 
         var headers = handler.getHttpRequestHeaders();
-        assertEquals(Map.of("buffer-operation", "replace"), headers);
+        assertEquals(ProxyMap.of("buffer-operation", "replace"), headers);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class HttpBodyTest {
     public void testOnHttpRequestBodyAppend() throws StartException {
         // Call callOnRequestBody
         handler.setHttpRequestHeaders(
-                Map.of(
+                ProxyMap.of(
                         "content-length", "10",
                         "buffer-operation", "append"));
 
@@ -111,7 +111,7 @@ public class HttpBodyTest {
     public void testOnHttpRequestBodyPrepend() throws StartException {
         // Call callOnRequestBody
         handler.setHttpRequestHeaders(
-                Map.of(
+                ProxyMap.of(
                         "content-length", "10",
                         "buffer-operation", "prepend"));
 
@@ -134,7 +134,7 @@ public class HttpBodyTest {
     public void testOnHttpRequestBodyReplace() throws StartException {
         // Call callOnRequestBody
         handler.setHttpRequestHeaders(
-                Map.of(
+                ProxyMap.of(
                         "content-length", "10",
                         "buffer-operation", "replace"));
 
@@ -157,7 +157,7 @@ public class HttpBodyTest {
 
         // Call OnRequestHeaders
         handler.setHttpRequestHeaders(
-                Map.of(
+                ProxyMap.of(
                         "buffer-replace-at", "response",
                         "content-length", "10",
                         "buffer-operation", "append"));
@@ -178,7 +178,7 @@ public class HttpBodyTest {
 
         // Call OnRequestHeaders
         handler.setHttpRequestHeaders(
-                Map.of(
+                ProxyMap.of(
                         "buffer-replace-at", "response",
                         "content-length", "10",
                         "buffer-operation", "prepend"));
@@ -199,7 +199,7 @@ public class HttpBodyTest {
 
         // Call OnRequestHeaders
         handler.setHttpRequestHeaders(
-                Map.of(
+                ProxyMap.of(
                         "buffer-replace-at", "response",
                         "content-length", "10",
                         "buffer-operation", "replace"));

--- a/src/test/java/io/roastedroot/proxywasm/examples/HttpHeadersTest.java
+++ b/src/test/java/io/roastedroot/proxywasm/examples/HttpHeadersTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.dylibso.chicory.wasm.Parser;
 import io.roastedroot.proxywasm.Action;
+import io.roastedroot.proxywasm.ProxyMap;
 import io.roastedroot.proxywasm.ProxyWasm;
 import io.roastedroot.proxywasm.StartException;
 import java.nio.file.Path;
-import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +28,7 @@ public class HttpHeadersTest {
             try (var host = proxyWasm.createHttpContext(handler)) {
                 id = host.id();
                 handler.setHttpRequestHeaders(
-                        Map.of(
+                        ProxyMap.of(
                                 "key1", "value1",
                                 "key2", "value2"));
                 var action = host.callOnRequestHeaders(false);
@@ -60,7 +60,7 @@ public class HttpHeadersTest {
             try (var host = proxyWasm.createHttpContext(handler)) {
                 id = host.id();
                 handler.setHttpResponseHeaders(
-                        Map.of(
+                        ProxyMap.of(
                                 "key1", "value1",
                                 "key2", "value2"));
                 var action = host.callOnResponseHeaders(false);
@@ -69,11 +69,11 @@ public class HttpHeadersTest {
 
             // Check headers
             assertEquals(
-                    Map.of(
+                    ProxyMap.of(
                             "key1", "value1",
                             "key2", "value2",
-                            "x-wasm-header", "x-value",
-                            "x-proxy-wasm-go-sdk-example", "http_headers"),
+                            "x-proxy-wasm-go-sdk-example", "http_headers",
+                            "x-wasm-header", "x-value"),
                     handler.getHttpResponseHeaders());
 
             // Check logs

--- a/src/test/java/io/roastedroot/proxywasm/examples/HttpRoutingTest.java
+++ b/src/test/java/io/roastedroot/proxywasm/examples/HttpRoutingTest.java
@@ -35,7 +35,7 @@ public class HttpRoutingTest {
                 assertEquals(Action.CONTINUE, action);
 
                 // Get and verify modified headers
-                Map<String, String> resultHeaders = handler.getHttpRequestHeaders();
+                var resultHeaders = handler.getHttpRequestHeaders();
                 assertEquals(1, resultHeaders.size());
                 assertEquals("my-host.com-canary", resultHeaders.get(":authority"));
             }
@@ -62,7 +62,7 @@ public class HttpRoutingTest {
                 assertEquals(Action.CONTINUE, action);
 
                 // Get and verify modified headers
-                Map<String, String> resultHeaders = handler.getHttpRequestHeaders();
+                var resultHeaders = handler.getHttpRequestHeaders();
                 assertEquals(1, resultHeaders.size());
                 assertEquals("my-host.com", resultHeaders.get(":authority"));
             }

--- a/src/test/java/io/roastedroot/proxywasm/examples/MockHandler.java
+++ b/src/test/java/io/roastedroot/proxywasm/examples/MockHandler.java
@@ -5,11 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.roastedroot.proxywasm.Action;
+import io.roastedroot.proxywasm.ArrayProxyMap;
 import io.roastedroot.proxywasm.ChainedHandler;
 import io.roastedroot.proxywasm.Handler;
 import io.roastedroot.proxywasm.Helpers;
 import io.roastedroot.proxywasm.LogLevel;
 import io.roastedroot.proxywasm.MetricType;
+import io.roastedroot.proxywasm.ProxyMap;
 import io.roastedroot.proxywasm.StreamType;
 import io.roastedroot.proxywasm.WasmException;
 import io.roastedroot.proxywasm.WasmResult;
@@ -30,14 +32,14 @@ public class MockHandler extends ChainedHandler {
         public final int statusCode;
         public final byte[] statusCodeDetails;
         public final byte[] body;
-        public final Map<String, String> headers;
+        public final ProxyMap headers;
         public final int grpcStatus;
 
         public HttpResponse(
                 int responseCode,
                 byte[] responseCodeDetails,
                 byte[] responseBody,
-                Map<String, String> additionalHeaders,
+                ProxyMap additionalHeaders,
                 int grpcStatus) {
             this.statusCode = responseCode;
             this.statusCodeDetails = responseCodeDetails;
@@ -50,12 +52,12 @@ public class MockHandler extends ChainedHandler {
     final ArrayList<String> loggedMessages = new ArrayList<>();
 
     private int tickPeriodMilliseconds;
-    private Map<String, String> httpRequestHeaders = new HashMap<>();
-    private Map<String, String> httpRequestTrailers = new HashMap<>();
-    private Map<String, String> httpResponseHeaders = new HashMap<>();
-    private Map<String, String> httpResponseTrailers = new HashMap<>();
-    private Map<String, String> grpcReceiveInitialMetadata = new HashMap<>();
-    private Map<String, String> grpcReceiveTrailerMetadata = new HashMap<>();
+    private ProxyMap httpRequestHeaders = new ArrayProxyMap();
+    private ProxyMap httpRequestTrailers = new ArrayProxyMap();
+    private ProxyMap httpResponseHeaders = new ArrayProxyMap();
+    private ProxyMap httpResponseTrailers = new ArrayProxyMap();
+    private ProxyMap grpcReceiveInitialMetadata = new ArrayProxyMap();
+    private ProxyMap grpcReceiveTrailerMetadata = new ArrayProxyMap();
     private HttpResponse senthttpResponse;
 
     private byte[] funcCallData = new byte[0];
@@ -127,67 +129,79 @@ public class MockHandler extends ChainedHandler {
     }
 
     @Override
-    public Map<String, String> getHttpRequestHeaders() {
+    public ProxyMap getHttpRequestHeaders() {
         return httpRequestHeaders;
     }
 
     @Override
-    public Map<String, String> getHttpRequestTrailers() {
+    public ProxyMap getHttpRequestTrailers() {
         return httpRequestTrailers;
     }
 
     @Override
-    public Map<String, String> getHttpResponseHeaders() {
+    public ProxyMap getHttpResponseHeaders() {
         return httpResponseHeaders;
     }
 
     @Override
-    public Map<String, String> getHttpResponseTrailers() {
+    public ProxyMap getHttpResponseTrailers() {
         return httpResponseTrailers;
     }
 
     @Override
-    public Map<String, String> getGrpcReceiveInitialMetaData() {
+    public ProxyMap getGrpcReceiveInitialMetaData() {
         return grpcReceiveInitialMetadata;
     }
 
     @Override
-    public Map<String, String> getGrpcReceiveTrailerMetaData() {
+    public ProxyMap getGrpcReceiveTrailerMetaData() {
         return grpcReceiveTrailerMetadata;
     }
 
     @Override
-    public WasmResult setHttpRequestHeaders(Map<String, String> headers) {
+    public WasmResult setHttpRequestHeaders(ProxyMap headers) {
         this.httpRequestHeaders = headers;
         return WasmResult.OK;
     }
 
+    public WasmResult setHttpRequestHeaders(Map<String, String> headers) {
+        return this.setHttpRequestHeaders(new ArrayProxyMap(headers));
+    }
+
     @Override
-    public WasmResult setHttpRequestTrailers(Map<String, String> trailers) {
+    public WasmResult setHttpRequestTrailers(ProxyMap trailers) {
         this.httpRequestTrailers = trailers;
         return WasmResult.OK;
     }
 
+    public WasmResult setHttpRequestTrailers(Map<String, String> headers) {
+        return this.setHttpRequestTrailers(new ArrayProxyMap(headers));
+    }
+
     @Override
-    public WasmResult setHttpResponseHeaders(Map<String, String> headers) {
+    public WasmResult setHttpResponseHeaders(ProxyMap headers) {
         this.httpResponseHeaders = headers;
         return WasmResult.OK;
     }
 
+    public WasmResult setHttpResponseHeaders(Map<String, String> headers) {
+        return this.setHttpResponseHeaders(new ArrayProxyMap(headers));
+    }
+
     @Override
-    public WasmResult setHttpResponseTrailers(Map<String, String> trailers) {
+    public WasmResult setHttpResponseTrailers(ProxyMap trailers) {
         this.httpResponseTrailers = trailers;
         return WasmResult.OK;
     }
 
     @Override
-    public WasmResult setGrpcReceiveInitialMetaData(Map<String, String> metadata) {
+    public WasmResult setGrpcReceiveInitialMetaData(ProxyMap metadata) {
         this.grpcReceiveInitialMetadata = metadata;
         return WasmResult.OK;
     }
 
     @Override
-    public WasmResult setGrpcReceiveTrailerMetaData(Map<String, String> metadata) {
+    public WasmResult setGrpcReceiveTrailerMetaData(ProxyMap metadata) {
         this.grpcReceiveTrailerMetadata = metadata;
         return WasmResult.OK;
     }
@@ -271,7 +285,7 @@ public class MockHandler extends ChainedHandler {
             int responseCode,
             byte[] responseCodeDetails,
             byte[] responseBody,
-            Map<String, String> additionalHeaders,
+            ProxyMap additionalHeaders,
             int grpcStatus) {
         this.senthttpResponse =
                 new HttpResponse(
@@ -298,16 +312,16 @@ public class MockHandler extends ChainedHandler {
         public final String uri;
         public final Object headers;
         public final byte[] body;
-        public final HashMap<String, String> trailers;
+        public final ProxyMap trailers;
         public final int timeoutMilliseconds;
 
         public HttpCall(
                 int id,
                 Type callType,
                 String uri,
-                HashMap<String, String> headers,
+                ProxyMap headers,
                 byte[] body,
-                HashMap<String, String> trailers,
+                ProxyMap trailers,
                 int timeoutMilliseconds) {
             this.id = id;
             this.callType = callType;
@@ -320,7 +334,7 @@ public class MockHandler extends ChainedHandler {
     }
 
     private final AtomicInteger lastCallId = new AtomicInteger(0);
-    private final HashMap<Integer, HttpCall> httpCalls = new HashMap<>();
+    private final HashMap<Integer, HttpCall> httpCalls = new HashMap();
 
     public HashMap<Integer, HttpCall> getHttpCalls() {
         return httpCalls;
@@ -328,11 +342,7 @@ public class MockHandler extends ChainedHandler {
 
     @Override
     public int httpCall(
-            String uri,
-            HashMap<String, String> headers,
-            byte[] body,
-            HashMap<String, String> trailers,
-            int timeoutMilliseconds)
+            String uri, ProxyMap headers, byte[] body, ProxyMap trailers, int timeoutMilliseconds)
             throws WasmException {
         var id = lastCallId.incrementAndGet();
         HttpCall value =
@@ -351,9 +361,9 @@ public class MockHandler extends ChainedHandler {
     @Override
     public int dispatchHttpCall(
             String upstreamName,
-            HashMap<String, String> headers,
+            ProxyMap headers,
             byte[] body,
-            HashMap<String, String> trailers,
+            ProxyMap trailers,
             int timeoutMilliseconds)
             throws WasmException {
         var id = lastCallId.incrementAndGet();
@@ -385,8 +395,8 @@ public class MockHandler extends ChainedHandler {
     }
 
     private final AtomicInteger lastMetricId = new AtomicInteger(0);
-    private HashMap<Integer, Metric> metrics = new HashMap<>();
-    private HashMap<String, Metric> metricsByName = new HashMap<>();
+    private HashMap<Integer, Metric> metrics = new HashMap();
+    private HashMap<String, Metric> metricsByName = new HashMap();
 
     @Override
     public int defineMetric(MetricType type, String name) throws WasmException {


### PR DESCRIPTION
This allows us to support repeated headers.