### PR TITLE
feat: upgrade Chicory runtime to v1.4.0 and improve build configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <junit.version>5.12.2</junit.version>
 
     <!-- runtime versions -->
-    <chicory.version>1.3.0</chicory.version>
+    <chicory.version>1.4.0</chicory.version>
     <jersey.version>3.1.10</jersey.version>
     <jetty.version>11.0.25</jetty.version>
 
@@ -112,11 +112,18 @@
                 <formatJavadoc>false</formatJavadoc>
               </googleJavaFormat>
               <importOrder/>
-              <replaceRegex>
-                <name>Remove wildcard imports</name>
-                <searchRegex>import\s+(?:static\s+)?[^\*\s]+\*;(\r\n|\r|\n)</searchRegex>
-                <replacement>$1</replacement>
-              </replaceRegex>
+              <jsr223>
+                <name>Wildcard Imports Not Allowed</name>
+                <dependency>org.apache.groovy:groovy-jsr223:4.0.27</dependency>
+                <engine>groovy</engine>
+                <script>def pattern = ~/import\s+(?:static\s+)?[^\*\s]+\*;(\r\n|\r|\n)/
+                                    def matcher = pattern.matcher(source)
+                                    if (matcher.find()) {
+                                    def importText = matcher.group().trim()
+                                    throw new Exception("Wildcard imports not allowed:\n\n    " + importText + "\n\nPlease fully expand the imports.\n")
+                                    }
+                                    source</script>
+              </jsr223>
               <removeUnusedImports/>
             </java>
             <pom>
@@ -213,6 +220,15 @@
               <version>${checkstyle.version}</version>
             </dependency>
           </dependencies>
+          <executions>
+            <execution>
+              <id>checkstyle</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <phase>validate</phase>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -230,6 +246,59 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>ci</id>
+      <activation>
+        <property>
+          <name>env.CI</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>check-format</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <phase>process-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>not-ci</id>
+      <activation>
+        <property>
+          <name>env.CI</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>format</id>
+                <goals>
+                  <goal>apply</goal>
+                </goals>
+                <phase>process-sources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>release</id>
       <build>

--- a/proxy-wasm-java-host/pom.xml
+++ b/proxy-wasm-java-host/pom.xml
@@ -16,12 +16,12 @@
   <dependencies>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>
-      <artifactId>aot-experimental</artifactId>
+      <artifactId>annotations</artifactId>
       <version>${chicory.version}</version>
     </dependency>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>
-      <artifactId>host-module-annotations-experimental</artifactId>
+      <artifactId>chicory-compiler-maven-plugin</artifactId>
       <version>${chicory.version}</version>
     </dependency>
     <dependency>
@@ -58,33 +58,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>format</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>process-sources</phase>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>checkstyle</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <phase>validate</phase>
-          </execution>
-        </executions>
-      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -93,7 +66,7 @@
           <annotationProcessorPaths>
             <path>
               <groupId>com.dylibso.chicory</groupId>
-              <artifactId>host-module-processor-experimental</artifactId>
+              <artifactId>annotations-processor</artifactId>
               <version>${chicory.version}</version>
             </path>
           </annotationProcessorPaths>

--- a/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/Plugin.java
+++ b/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/Plugin.java
@@ -301,9 +301,10 @@ public interface Plugin {
          * The {@link Machine} controls the low-level execution of WASM instructions.
          * By default, an interpreter-based machine is used.
          * Providing a custom factory allows using alternative execution strategies, such as
-         * Ahead-Of-Time (AOT) compilation to improve execution performance.
+         * wasm to bytecode compilation to improve execution performance.
          *
-         * <p>See the Chicory documentation (https://chicory.dev/docs/experimental/aot) for more details on Aot compilation.
+         * <p>See the Chicory documentation (https://chicory.dev/docs/usage/runtime-compiler) for more details
+         * on WASM to bytecode compilation and execution.
          *
          * @param machineFactory A function that takes a WASM {@link Instance} and returns a {@link Machine}.
          * @return this {@code Builder} instance for method chaining.

--- a/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/internal/ABI.java
+++ b/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/internal/ABI.java
@@ -5,8 +5,8 @@ import static io.roastedroot.proxywasm.internal.Helpers.replaceBytes;
 import static io.roastedroot.proxywasm.internal.Helpers.split;
 import static io.roastedroot.proxywasm.internal.Helpers.string;
 
-import com.dylibso.chicory.experimental.hostmodule.annotations.HostModule;
-import com.dylibso.chicory.experimental.hostmodule.annotations.WasmExport;
+import com.dylibso.chicory.annotations.HostModule;
+import com.dylibso.chicory.annotations.WasmExport;
 import com.dylibso.chicory.runtime.ExportFunction;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Memory;


### PR DESCRIPTION
• Upgrade Chicory WebAssembly runtime from version 1.3.0 to 1.4.0 • Update Chicory dependency artifact names to new stable packages:
  - Replace experimental aot-experimental with annotations
  - Replace host-module-annotations-experimental with chicory-compiler-maven-plugin
  - Replace host-module-processor-experimental with annotations-processor • Improve Spotless configuration with enhanced wildcard import detection:
  - Replace simple regex-based wildcard import removal with Groovy-based validation
  - Add clear error messages for wildcard imports requiring manual expansion • Add not-ci profile for automatic code formatting during local development • Update documentation references to point to current Chicory runtime compiler docs

This upgrade modernizes the project's WebAssembly runtime dependencies and improves the developer experience by providing better build validation and automatic code formatting. The Chicory 1.4.0 upgrade brings performance improvements and stability enhancements to WebAssembly execution.