### PR TITLE
Lazy load request/response bodies fixes #50

### DIFF
--- a/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/internal/HttpRequestBody.java
+++ b/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/internal/HttpRequestBody.java
@@ -1,0 +1,55 @@
+package io.roastedroot.proxywasm.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Supplier;
+
+/**
+ * Holds the HTTP request body, loading it from a stream when first accessed.
+ */
+public class HttpRequestBody {
+
+    private byte[] body;
+    private boolean loaded = false;
+    private final Supplier<InputStream> streamSupplier;
+
+    public HttpRequestBody(Supplier<InputStream> streamSupplier) {
+        this.streamSupplier = streamSupplier;
+    }
+
+    public byte[] get() {
+        if (!loaded) {
+            try {
+                body = streamSupplier.get().readAllBytes();
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to read request body", e);
+            }
+            loaded = true;
+        }
+        return body;
+    }
+
+    /**
+     * Returns true if the request body has been loaded from the stream.
+     */
+    public boolean isLoaded() {
+        return loaded;
+    }
+
+    /**
+     * Sets the request body directly, marking it as loaded.
+     * This is used when the body is modified by WASM plugins.
+     */
+    public void setBody(byte[] body) {
+        this.body = body;
+        this.loaded = true;
+    }
+
+    /**
+     * Returns the request body if it has been loaded, null otherwise.
+     * This allows checking if the body was accessed without triggering a load.
+     */
+    public byte[] getBodyIfLoaded() {
+        return loaded ? body : null;
+    }
+}

--- a/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/internal/HttpResponseBody.java
+++ b/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/internal/HttpResponseBody.java
@@ -1,0 +1,64 @@
+package io.roastedroot.proxywasm.internal;
+
+import java.util.function.Supplier;
+
+/**
+ * Holds the HTTP response body, loading it from a supplier when first accessed.
+ * Unlike request bodies which come from streams, response bodies can be provided
+ * directly as byte arrays or from suppliers.
+ */
+public class HttpResponseBody {
+
+    private byte[] body;
+    private boolean loaded = false;
+    private final Supplier<byte[]> bodySupplier;
+
+    public HttpResponseBody(Supplier<byte[]> bodySupplier) {
+        this.bodySupplier = bodySupplier;
+    }
+
+    /**
+     * Creates an HttpResponseBody with a fixed byte array (no lazy loading needed).
+     */
+    public HttpResponseBody(byte[] body) {
+        this.body = body;
+        this.loaded = true;
+        this.bodySupplier = null;
+    }
+
+    public byte[] get() {
+        if (!loaded) {
+            if (bodySupplier != null) {
+                body = bodySupplier.get();
+            } else {
+                body = new byte[0];
+            }
+            loaded = true;
+        }
+        return body;
+    }
+
+    /**
+     * Returns true if the response body has been loaded.
+     */
+    public boolean isLoaded() {
+        return loaded;
+    }
+
+    /**
+     * Sets the response body directly, marking it as loaded.
+     * This is used when the body is modified by WASM plugins.
+     */
+    public void setBody(byte[] body) {
+        this.body = body;
+        this.loaded = true;
+    }
+
+    /**
+     * Returns the response body if it has been loaded, null otherwise.
+     * This allows checking if the body was accessed without triggering a load.
+     */
+    public byte[] getBodyIfLoaded() {
+        return loaded ? body : null;
+    }
+}


### PR DESCRIPTION
commit 6dca5a046b8af7c1b2eb8ded9a61b0020d068909 (HEAD -> lazy-loading, chirino/lazy-loading)
Author: Hiram Chirino <hiram@hiramchirino.com>
Date:   Mon Jun 2 16:22:20 2025 -0400

    feat: implement lazy response body loading for improved memory efficiency
    
    • Add HttpResponseBody class for lazy response body management with supplier-based loading
    • Add deferred loading mechanism - response body only loaded when WASM modules access it
    • Fix request body processing logic to properly handle early returns for non-body plugins
    • Update response header filtering logic to skip unnecessary processing when no body handling needed
    
    This implementation extends the existing lazy request body loading concept to response bodies,
    providing significant memory and performance improvements. The lazy loading mechanism ensures
    response bodies are only read from the output stream when WASM plugins actually call
    proxy_get_buffer_bytes to access the data. This prevents unnecessary memory allocation and
    I/O operations for plugins that process headers but don't need response body content, while
    maintaining full backward compatibility with existing plugin implementations.
    
    Signed-off-by: Hiram Chirino <hiram@hiramchirino.com>

commit 4bb0309b64e34383221cecaf5b70316735d38dde
Author: Hiram Chirino <hiram@hiramchirino.com>
Date:   Mon Jun 2 14:44:22 2025 -0400

    refactor: implement lazy request body loading with dedicated HttpRequestBody class
    
    • Created new HttpRequestBody class to encapsulate lazy loading logic and state
    • Refactored PluginHttpContext to use HttpRequestBody instead of managing state directly
    • Updated ProxyWasmFilter to use shared HttpRequestBody instance across plugins
    • Improved request body processing loop with proper action handling
    • Enhanced type safety by removing Object-based field types
    • Moved body state management from context to dedicated supplier class
    
    This refactoring addresses memory efficiency concerns by only loading request bodies
    when WASM modules actually access them via proxy_get_buffer_bytes.
    
    Signed-off-by: Hiram Chirino <hiram@hiramchirino.com>