### PR TITLE
feat: enhance PluginFactory with properties management

### DIFF
--- a/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/PluginFactory.java
+++ b/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/PluginFactory.java
@@ -8,7 +8,9 @@ import com.dylibso.chicory.runtime.Machine;
 import com.dylibso.chicory.wasm.WasmModule;
 import io.roastedroot.proxywasm.internal.ProxyWasm;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -82,6 +84,7 @@ public interface PluginFactory {
         private SharedQueueHandler sharedQueueHandler;
         private SharedDataHandler sharedDataHandler;
         private boolean shared;
+        private HashMap<List<String>, byte[]> properties = new HashMap<>();
 
         /**
          * Private constructor for the Builder.
@@ -102,6 +105,42 @@ public interface PluginFactory {
          */
         public PluginFactory.Builder withName(String name) {
             this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets the properties for this plugin instance.
+         *
+         * @param properties A map where keys are the property names expected by the WASM module,
+         *                  and values are the corresponding byte arrays.
+         * @return this {@code Builder} instance for method chaining.
+         */
+        public PluginFactory.Builder withProperties(Map<List<String>, byte[]> properties) {
+            this.properties = new HashMap<>(properties);
+            return this;
+        }
+
+        /**
+         * Sets a single property for this plugin instance.
+         *
+         * @param key The key of the property to set.
+         * @param value The value of the property to set.
+         * @return this {@code Builder} instance for method chaining.
+         */
+        public PluginFactory.Builder withProperty(List<String> key, byte[] value) {
+            this.properties.put(key, value);
+            return this;
+        }
+
+        /**
+         * Sets a single property for this plugin instance.
+         *
+         * @param key The key of the property to set.
+         * @param value The value of the property to set.
+         * @return this {@code Builder} instance for method chaining.
+         */
+        public PluginFactory.Builder withProperty(List<String> key, String value) {
+            this.properties.put(key, bytes(value));
             return this;
         }
 
@@ -362,6 +401,15 @@ public interface PluginFactory {
             SharedDataHandler sharedDataHandler = this.sharedDataHandler;
             boolean shared = this.shared;
 
+            HashMap<List<String>, byte[]> properties = new HashMap<>();
+            if (this.properties != null) {
+                for (Map.Entry<List<String>, byte[]> listEntry : this.properties.entrySet()) {
+                    byte[] value = listEntry.getValue();
+                    value = Arrays.copyOf(value, value.length);
+                    this.properties.put(List.copyOf(listEntry.getKey()), value);
+                }
+            }
+
             return new PluginFactory() {
 
                 @Override
@@ -389,7 +437,8 @@ public interface PluginFactory {
                             pluginConfig,
                             metricsHandler,
                             sharedQueueHandler,
-                            sharedDataHandler);
+                            sharedDataHandler,
+                            properties);
                 }
             };
         }

--- a/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/internal/Plugin.java
+++ b/proxy-wasm-java-host/src/main/java/io/roastedroot/proxywasm/internal/Plugin.java
@@ -6,6 +6,7 @@ import static io.roastedroot.proxywasm.internal.WellKnownHeaders.METHOD;
 import static io.roastedroot.proxywasm.internal.WellKnownHeaders.PATH;
 import static io.roastedroot.proxywasm.internal.WellKnownHeaders.SCHEME;
 import static io.roastedroot.proxywasm.internal.WellKnownProperties.PLUGIN_NAME;
+import static io.roastedroot.proxywasm.internal.WellKnownProperties.PLUGIN_ROOT_ID;
 import static io.roastedroot.proxywasm.internal.WellKnownProperties.PLUGIN_VM_ID;
 
 import io.roastedroot.proxywasm.ForeignFunction;
@@ -50,7 +51,8 @@ public final class Plugin implements io.roastedroot.proxywasm.Plugin {
             byte[] pluginConfig,
             MetricsHandler metricsHandler,
             SharedQueueHandler sharedQueueHandler,
-            SharedDataHandler sharedDataHandler)
+            SharedDataHandler sharedDataHandler,
+            HashMap<List<String>, byte[]> properties)
             throws StartException {
         Objects.requireNonNull(proxyWasm);
         this.name = Objects.requireNonNullElse(name, "default");
@@ -61,12 +63,12 @@ public final class Plugin implements io.roastedroot.proxywasm.Plugin {
         this.vmConfig = vmConfig;
         this.pluginConfig = pluginConfig;
         this.logger = Objects.requireNonNullElse(logger, LogHandler.DEFAULT);
-        ;
         this.metricsHandler = Objects.requireNonNullElse(metricsHandler, MetricsHandler.DEFAULT);
         this.sharedQueueHandler =
                 Objects.requireNonNullElse(sharedQueueHandler, SharedQueueHandler.DEFAULT);
         this.sharedDataHandler =
                 Objects.requireNonNullElse(sharedDataHandler, SharedDataHandler.DEFAULT);
+        this.properties = Objects.requireNonNull(properties);
 
         this.wasm = proxyWasm;
         this.wasm.setPluginHandler(new HandlerImpl());
@@ -138,7 +140,7 @@ public final class Plugin implements io.roastedroot.proxywasm.Plugin {
     private Runnable cancelTick;
     private final HashMap<String, ForeignFunction> foreignFunctions;
     private byte[] funcCallData = new byte[0];
-    private final HashMap<List<String>, byte[]> properties = new HashMap<>();
+    private final HashMap<List<String>, byte[]> properties;
 
     class HandlerImpl extends ChainedHandler {
 
@@ -168,6 +170,9 @@ public final class Plugin implements io.roastedroot.proxywasm.Plugin {
         public byte[] getProperty(List<String> path) throws WasmException {
             // TODO: do we need field for vm_id and root_id?
             if (PLUGIN_VM_ID.equals(path)) {
+                return bytes(name);
+            }
+            if (PLUGIN_ROOT_ID.equals(path)) {
                 return bytes(name);
             }
             if (PLUGIN_NAME.equals(path)) {


### PR DESCRIPTION
- Added a properties field to the PluginFactory.Builder for managing plugin properties.
- Introduced methods `withProperties` and `withProperty` to set multiple or single properties respectively.
- Updated the Plugin constructor to accept properties and ensure they are properly initialized.
- return a value for the pluign_root_id property 

This commit enhances the PluginFactory by allowing users to define and manage properties for plugin instances. The new methods facilitate easier configuration of properties, improving the flexibility and usability of the PluginFactory. This change is expected to streamline the process of setting up plugins with specific configurations, ultimately leading to a more robust implementation of the proxy-wasm functionality.